### PR TITLE
Make `environment` special syntax

### DIFF
--- a/test/repeat.fig
+++ b/test/repeat.fig
@@ -1,0 +1,3 @@
+#lang fig
+
+@a

--- a/test/runner.rkt
+++ b/test/runner.rkt
@@ -91,3 +91,10 @@
        "plus result" 4
        "list result" '(1 2 3))
  "Fig should apply Racket functions correctly.")
+
+(test-case "environment is not shared across runs"
+  (define result0 (run-file "repeat.fig" (hash "a" 42)))
+  (check-equal? result0 42)
+  (check-exn exn:fail:user?
+             (λ ()
+               (run-file "repeat.fig" (hash)))))


### PR DESCRIPTION
Instead of copying into a shared `environment` value, this creates a syntax parameter that can be bound to the `env` argument in the generated `fig->hash` function.